### PR TITLE
[codex] Polish fr-FR laugh locale

### DIFF
--- a/locale/fr-FR/dialog/cancel.dialog
+++ b/locale/fr-FR/dialog/cancel.dialog
@@ -1,2 +1,2 @@
-je ne rirais plus
-rire arrêté
+c'est bon, je m'arrête
+d'accord, j'arrête de rire

--- a/locale/fr-FR/dialog/cancel_fail.dialog
+++ b/locale/fr-FR/dialog/cancel_fail.dialog
@@ -1,1 +1,1 @@
-ça ne me fait pas rire
+je ne suis pas en train de rire

--- a/locale/fr-FR/dialog/maybe.dialog
+++ b/locale/fr-FR/dialog/maybe.dialog
@@ -1,3 +1,3 @@
-Non
-peut être
+non
+peut-être
 qui sait

--- a/locale/fr-FR/dialog/yes.dialog
+++ b/locale/fr-FR/dialog/yes.dialog
@@ -1,1 +1,1 @@
-Oui
+oui, absolument

--- a/locale/fr-FR/skill.json
+++ b/locale/fr-FR/skill.json
@@ -1,0 +1,14 @@
+{
+  "title": "Rire",
+  "url": "https://github.com/OpenVoiceOS/ovos-skill-laugh",
+  "description": "Demandez à votre assistant vocal de rire sur commande ou de manière aléatoire.",
+  "examples": [
+    "Ris comme Alexa",
+    "Peux-tu rire ?"
+  ],
+  "tags": [
+    "rire",
+    "divertissement",
+    "assistant vocal"
+  ]
+}

--- a/locale/fr-FR/vocab/Laugh.intent
+++ b/locale/fr-FR/vocab/Laugh.intent
@@ -1,7 +1,19 @@
-peux tu rigoler ?
-peux tu rire ?
-ricane
-rigole comme alexa
-rire démoniaque
-rire sadique
-ris comme alexa
+fais un rire diabolique
+fais un rire démoniaque
+fais un rire maléfique
+fais un rire sinistre
+j'aimerais que tu ries
+je veux que tu ries
+montre-moi ton rire
+peux-tu rigoler
+peux-tu rire
+pourquoi tu ne ris pas
+qu'est-ce qui t'empêche de rire
+ricane un peu
+rigole
+ris
+ris comme Alexa
+ris méchamment
+ris un peu
+tu aimes rire
+tu peux rire

--- a/locale/fr-FR/vocab/RandomLaugh.intent
+++ b/locale/fr-FR/vocab/RandomLaugh.intent
@@ -1,4 +1,12 @@
+active le mode rire aléatoire
 active le rire aléatoire
-rigole aléatoirement
+déclenche un rire aléatoire
+fais des rires aléatoires
+fais un rire au hasard
+lance un rire aléatoire
+rigole au hasard
 rire aléatoire
+rires aléatoires
 ris aléatoirement
+ris au hasard
+surprends-moi avec un rire

--- a/locale/fr-FR/vocab/Stop.voc
+++ b/locale/fr-FR/vocab/Stop.voc
@@ -1,5 +1,5 @@
 abandonne
 annule
 arrête
-c'est pas drôle
+ce n'est pas drôle
 stop

--- a/locale/fr-FR/vocab/haunted.intent
+++ b/locale/fr-FR/vocab/haunted.intent
@@ -1,2 +1,3 @@
-As-tu besoin d'un exorcisme
-Es-tu hanté?
+as-tu besoin d'un exorcisme
+es-tu hanté
+es-tu possédé

--- a/translations/fr-fr/dialogs.json
+++ b/translations/fr-fr/dialogs.json
@@ -1,17 +1,17 @@
 {
   "/dialog/cancel_fail.dialog": [
-    "ça ne me fait pas rire"
+    "je ne suis pas en train de rire"
   ],
   "/dialog/yes.dialog": [
-    "Oui"
+    "oui, absolument"
   ],
   "/dialog/cancel.dialog": [
-    "rire arrêté",
-    "je ne rirais plus"
+    "d'accord, j'arrête de rire",
+    "c'est bon, je m'arrête"
   ],
   "/dialog/maybe.dialog": [
-    "Non",
-    "peut être",
+    "non",
+    "peut-être",
     "qui sait"
   ]
 }

--- a/translations/fr-fr/intents.json
+++ b/translations/fr-fr/intents.json
@@ -1,16 +1,42 @@
 {
   "/vocab/RandomLaugh.intent": [
-    "(ris|rigole) aléatoirement",
-    "(active le|) rire aléatoire",
-    "rire aléatoire"
+    "active le mode rire aléatoire",
+    "active le rire aléatoire",
+    "déclenche un rire aléatoire",
+    "fais des rires aléatoires",
+    "fais un rire au hasard",
+    "lance un rire aléatoire",
+    "rigole au hasard",
+    "rire aléatoire",
+    "rires aléatoires",
+    "ris aléatoirement",
+    "ris au hasard",
+    "surprends-moi avec un rire"
   ],
   "/vocab/Laugh.intent": [
-    "(ris|rigole) comme alexa",
-    "peux tu (rire|rigoler) ?",
-    "(ricane|rire démoniaque|rire sadique)"
+    "fais un rire démoniaque",
+    "fais un rire diabolique",
+    "fais un rire maléfique",
+    "fais un rire sinistre",
+    "j'aimerais que tu ries",
+    "je veux que tu ries",
+    "montre-moi ton rire",
+    "peux-tu rire",
+    "peux-tu rigoler",
+    "pourquoi tu ne ris pas",
+    "qu'est-ce qui t'empêche de rire",
+    "ricane un peu",
+    "rigole",
+    "ris",
+    "ris comme Alexa",
+    "ris méchamment",
+    "ris un peu",
+    "tu aimes rire",
+    "tu peux rire"
   ],
   "/vocab/haunted.intent": [
-    "Es-tu hanté?",
-    "As-tu besoin d'un exorcisme"
+    "as-tu besoin d'un exorcisme",
+    "es-tu hanté",
+    "es-tu possédé"
   ]
 }

--- a/translations/fr-fr/vocabs.json
+++ b/translations/fr-fr/vocabs.json
@@ -1,7 +1,13 @@
 {
+  "/vocab/Laugh.voc": [
+    "rire",
+    "rigoler"
+  ],
   "/vocab/Stop.voc": [
     "abandonne",
     "annule",
-    "(stop|arrête|c'est pas drôle)"
+    "arrête",
+    "ce n'est pas drôle",
+    "stop"
   ]
 }


### PR DESCRIPTION
## Summary
- Polish fr-FR Laugh locale responses so the assistant sounds less robotic in spoken interactions.
- Keep regular laugh, random laugh, stop, and haunted intent surfaces distinct.
- Add the fr-FR skill metadata and keep source translation JSON aligned with canonical `locale/fr-FR` resources.

## Validation
- JSON parse for fr-FR translation files and `locale/fr-FR/skill.json`
- Duplicate intent-line scan for fr-FR resources
- Raw `API` scan for fr-FR resources
- `git diff --check origin/dev..HEAD`
- `python -m compileall -q __init__.py locale translations`

## Review Notes
- Locale-only; no runtime changes.
- Rebased onto current `dev` after upstream normalized locale directory casing.
- CodeRabbit skipped because the PR is draft; no actionable review comments were present.
